### PR TITLE
flaky fix to commons-collections

### DIFF
--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -705,17 +705,18 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         map.put((K) "B", (V) "U");
         map.put((K) "B", (V) "V");
         map.put((K) "B", (V) "W");
+        String actualToString = map.toString();
         assertTrue(
-            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
-            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(actualToString) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(actualToString)
         );
 
         final MultiValuedMap<K, V> originalNull = null;
         assertThrows(NullPointerException.class, () -> map.putAll(originalNull),
                 "expecting NullPointerException");
         assertTrue(
-            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
-            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(actualToString) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(actualToString)
         );
 
         map.remove("A");


### PR DESCRIPTION
The test : [org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest.testToString](https://github.com/kevin952/commons-collections/blob/af6fff168cc253e82b4b6fcf17be04ebfd6e2b44/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L697)

Lets Dive deeper into this Test and the fix provided for the issue:

**Flakiness:**
To check the flakiness of the test, I used a tool called **[nondex](https://github.com/TestingResearchIllinois/NonDex)**.

You can reproduce the test using the commands below:

   ```shell
   mvn install -pl . -am -DskipTests
   mvn  -Dtest=org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest#testToString
  mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest#testToString
```

Using the commands above I determined the test to be Flaky.

**Issue:**
```
  public MultiValuedMap<K, V> makeObject() {
        return TransformedMultiValuedMap.transformingMap(new ArrayListValuedHashMap<>(),
                TransformerUtils.<K>nopTransformer(), TransformerUtils.<V>nopTransformer());
    }
```
The `toString()` function is not inherently flaky and thus is not the root cause of the issue. `MultiValuedMap` is what causes the issue as this can change the order of the keys.

**Fix:**
To address this, I introduced a fix by introducing a new variable `actualToString = map.toString()` which ensures that the multi-valued map remains in either of the assertions the developer expects.

I added this variable to the assertions and thus provided a convincing fix to the issue. It passed on multiple nondex runs as well.

**NOTE:** The solution provided maintains the intention of the developer. As you see the assertion, the developer expects the map to be either of the solutions i.e. `a first and then b`  or `b first and then a` expecting a change in the order. This is why, I introduced a variable and did not change the inherent order of the multimap.

Do let me know if you have any questions. Please leave a LGTM if you find this fix useful! Thanks!