### PR TITLE
Flaky fix 2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.0
+      uses: actions/checkout@v4.1.1
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@v3.3.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.6.0
+      uses: actions/checkout@v4.0.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         java: [ 8 ]
 
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4.1.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@v3.3.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.13.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         java: [ 8 ]
 
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v4.1.1
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         java: [ 8 ]
 
     steps:
-    - uses: actions/checkout@v3.5.3
+    - uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         java: [ 8 ]
 
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.0.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn -V test jacoco:report --file pom.xml --no-transfer-progress
+      run: mvn --show-version --batch-mode --no-transfer-progress test jacoco:report
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         experimental: [false]
 #        include:
 #          - java: 18-ea

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
         java: [ 8, 11, 17, 21 ]
         experimental: [false]
 #        include:
-#          - java: 18-ea
+#          - java: 22-ea
 #            experimental: true
         
     steps:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3.12.0
+      uses: actions/setup-java@v3.13.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
 #            experimental: true
         
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v4.1.1
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@v3.3.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
 #            experimental: true
         
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4.1.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
 #            experimental: true
         
     steps:
-    - uses: actions/checkout@v3.5.3
+    - uses: actions/checkout@v3.6.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
 #            experimental: true
         
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.0.0
       with:
         persist-credentials: false
     - uses: actions/cache@v3.3.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,4 +50,4 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       # Use the default goal
-      run: mvn -V --file pom.xml --no-transfer-progress
+      run: mvn --show-version --batch-mode --no-transfer-progress

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -57,7 +57,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce    # 3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32    # 3.1.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031    # 2.2.0
+        uses: ossf/scorecard-action@483ef80eb98fb506c348f7d62e28055e49fe2398    # 2.3.0
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@483ef80eb98fb506c348f7d62e28055e49fe2398    # 2.3.0
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736    # 2.3.1
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@v3.6.0 # v3.5.3
+        uses: actions/checkout@v4.0.0 # v3.5.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@v3.6.0 # v3.5.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@v4.0.0 # v3.5.3
+        uses: actions/checkout@v4.1.0 # v3.5.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@v4.1.0 # v3.5.3
+        uses: actions/checkout@v4.1.1 # v3.5.3
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@
 Apache Commons Collections
 ===================
 
-[![GitHub Actions Status](https://github.com/apache/commons-collections/workflows/Java%20CI/badge.svg)](https://github.com/apache/commons-collections/actions)
+[![Java CI](https://github.com/apache/commons-collections/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/commons-collections/actions/workflows/maven.yml)
 [![Coverage Status](https://codecov.io/gh/apache/commons-collections/branch/master/graph/badge.svg)](https://app.codecov.io/gh/apache/commons-collections/branch/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-collections4/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-collections4/?gav=true)
 [![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-collections4/4.4.svg)](https://javadoc.io/doc/org.apache.commons/commons-collections4/4.4)
-[![CodeQL](https://github.com/apache/commons-collections/workflows/CodeQL/badge.svg)](https://github.com/apache/commons-collections/actions/workflows/codeql-analysis.yml?query=workflow%3ACodeQL)
+[![CodeQL](https://github.com/apache/commons-collections/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/apache/commons-collections/actions/workflows/codeql-analysis.yml)
 [![OpenSSF
 Scorecard](https://api.securityscorecards.dev/projects/github.com/apache/commons-collections/badge)](https://api.securityscorecards.dev/projects/github.com/apache/commons-collections)
 

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>32.1.2-jre</version>
+      <version>32.1.3-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>5.1.0</version>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>61</version>
+    <version>62</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>commons-collections4</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>59</version>
+    <version>61</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>commons-collections4</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.14.0</version>
+      <version>2.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>62</version>
+    <version>64</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>commons-collections4</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
+      <version>2.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -583,9 +583,6 @@
     <!--Commons Release Plugin -->
     <commons.bc.version>4.4</commons.bc.version>
     <commons.release.isDistModule>true</commons.release.isDistModule>
-    <commons.releaseManagerName>Gary Gregory</commons.releaseManagerName>    
-    <commons.releaseManagerKey>86fdc7e2a11262cb</commons.releaseManagerKey>
-
   </properties>
 
   <build>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -296,7 +296,7 @@
       Bump codecov/codecov-action from 2 to 3 #297.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory, Dependabot">
-      Bump Apache commons-parent from 48 to 61, #339.
+      Bump Apache commons-parent from 48 to 62, #339.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory">
       Bump Jacoco from 0.8.4 to 0.8.8.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -296,7 +296,7 @@
       Bump codecov/codecov-action from 2 to 3 #297.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory, Dependabot">
-      Bump Apache commons-parent from 48 to 62, #339.
+      Bump Apache commons-parent from 48 to 64, #339.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory">
       Bump Jacoco from 0.8.4 to 0.8.8.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -368,7 +368,7 @@
       Bump pmd from 6.46.0 to 6.52.0 #318, #327, #333, #347.
     </action>
     <action type="update" dev="ggregory" due-to="Dependabot">
-      Bump guava-testlib from 31.1-jre to 32.1.2-jre #394, #395, #404, #405, #411.
+      Bump guava-testlib from 31.1-jre to 32.1.3-jre #394, #395, #404, #405, #411, #423.
     </action>
   </release>
   <release version="4.4" date="2019-07-05" description="Maintenance release.">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -281,7 +281,7 @@
     </action>
     <!-- UPDATE -->
     <action dev="ggregory" type="update" due-to="Gary Gregory, Dependabot">
-      Bump org.easymock:easymock from 4.0.2 to 5.1.0 #352, #355, #375.
+      Bump org.easymock:easymock from 4.0.2 to 5.2.0 #352, #355, #375, #414.
     </action>
     <action type="update" dev="kinow" due-to="Dependabot, Gary Gregory">
       Bump actions/cache from 2 to 3.0.10 #214 #225 #239 #266 #294, #342, #345.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -296,7 +296,7 @@
       Bump codecov/codecov-action from 2 to 3 #297.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory, Dependabot">
-      Bump Apache commons-parent from 48 to 59, #339.
+      Bump Apache commons-parent from 48 to 61, #339.
     </action>
     <action dev="ggregory" type="update" due-to="Gary Gregory">
       Bump Jacoco from 0.8.4 to 0.8.8.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -323,7 +323,7 @@
       Remove deprecated sudo setting. #161.
     </action>
     <action type="update" dev="ggregory" due-to="Gary Gregory">
-      Bump tests from commons-io:commons-io 2.6 to 2.13.0 #180.
+      Bump tests from commons-io:commons-io 2.6 to 2.15.0 #180.
     </action>
     <action type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">
       Bump maven-pmd-plugin from 3.12.0 to 3.19.0 #167, #196, #253, #311, #334.

--- a/src/conf/checkstyle.xml
+++ b/src/conf/checkstyle.xml
@@ -17,8 +17,8 @@ limitations under the License.
 -->
 
 <!DOCTYPE module PUBLIC
-      "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
-      "https://checkstyle.org/dtds/configuration_1_2.dtd">
+      "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+      "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- Apache Commons Collections customization of default Checkstyle behavior -->
 <module name="Checker">

--- a/src/conf/checkstyle.xml
+++ b/src/conf/checkstyle.xml
@@ -42,6 +42,7 @@ limitations under the License.
     <property name="headerFile" value="${checkstyle.header.file}"/>
   </module>
   <module name="TreeWalker">
+    <module name="ExplicitInitializationCheck" />
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/>
     <module name="RedundantImport"/>

--- a/src/conf/checkstyle.xml
+++ b/src/conf/checkstyle.xml
@@ -63,5 +63,11 @@ limitations under the License.
       <!-- Indentation style recommended by Oracle -->
       <property name="caseIndent" value="0"/>
     </module>
+    <module name="ImportOrder">
+      <property name="option" value="top"/>
+      <property name="groups" value="java,javax,junit,org,com"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+    </module>
  </module>
 </module>

--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -161,7 +161,7 @@ public class CollectionUtils {
      * Helper class for set-related operations, e.g. union, subtract, intersection.
      * @param <O>  the element type
      */
-    private static class SetOperationCardinalityHelper<O> extends CardinalityHelper<O> implements Iterable<O> {
+    private static final class SetOperationCardinalityHelper<O> extends CardinalityHelper<O> implements Iterable<O> {
 
         /** Contains the unique elements of the two collections. */
         private final Set<O> elements;
@@ -712,7 +712,7 @@ public class CollectionUtils {
      * @param <O>  the element type
      * @since 4.0
      */
-    private static class EquatorWrapper<O> {
+    private static final class EquatorWrapper<O> {
         private final Equator<? super O> equator;
         private final O object;
 

--- a/src/main/java/org/apache/commons/collections4/ListUtils.java
+++ b/src/main/java/org/apache/commons/collections4/ListUtils.java
@@ -98,7 +98,7 @@ public class ListUtils {
      * Provides a partition view on a {@link List}.
      * @since 4.0
      */
-    private static class Partition<T> extends AbstractList<List<T>> {
+    private static final class Partition<T> extends AbstractList<List<T>> {
         private final List<T> list;
         private final int size;
 

--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -152,7 +152,7 @@ public class MapUtils {
      * Prints the given map with nice line breaks.
      * <p>
      * This method prints a nicely formatted String describing the Map. Each map entry will be printed with key, value
-     * and value classname. When the value is a Map, recursive behavior occurs.
+     * and value class name. When the value is a Map, recursive behavior occurs.
      * </p>
      * <p>
      * This method is NOT thread-safe in any special way. You must manually synchronize on either this class or the

--- a/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
@@ -44,7 +44,7 @@ public class SplitMapUtils {
     private SplitMapUtils() {}
 
 
-    private static class WrappedGet<K, V> implements IterableMap<K, V>, Unmodifiable {
+    private static final class WrappedGet<K, V> implements IterableMap<K, V>, Unmodifiable {
         private final Get<K, V> get;
 
         private WrappedGet(final Get<K, V> get) {
@@ -136,7 +136,7 @@ public class SplitMapUtils {
         }
     }
 
-    private static class WrappedPut<K, V> implements Map<K, V>, Put<K, V> {
+    private static final class WrappedPut<K, V> implements Map<K, V>, Put<K, V> {
         private final Put<K, V> put;
 
         private WrappedPut(final Put<K, V> put) {

--- a/src/main/java/org/apache/commons/collections4/bidimap/AbstractDualBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/AbstractDualBidiMap.java
@@ -332,6 +332,10 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class View.
+     *
+     * @param <K> the type of the keys in the map.
+     * @param <V> the type of the values in the map.
+     * @param <E> the type of the elements in the collection.
      */
     protected abstract static class View<K, V, E> extends AbstractCollectionDecorator<E> {
 
@@ -432,6 +436,8 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class KeySet.
+     *
+     * @param <K> the type of elements maintained by this set
      */
     protected static class KeySet<K> extends View<K, Object, K> implements Set<K> {
 
@@ -471,6 +477,8 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class KeySetIterator.
+     *
+     * @param <K> the key type.
      */
     protected static class KeySetIterator<K> extends AbstractIteratorDecorator<K> {
 
@@ -515,6 +523,8 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class Values.
+     *
+     * @param <V> the type of the values.
      */
     protected static class Values<V> extends View<Object, V, V> implements Set<V> {
 
@@ -554,6 +564,8 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class ValuesIterator.
+     *
+     * @param <V> the value type.
      */
     protected static class ValuesIterator<V> extends AbstractIteratorDecorator<V> {
 
@@ -598,6 +610,9 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class EntrySet.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class EntrySet<K, V> extends View<K, V, Map.Entry<K, V>> implements Set<Map.Entry<K, V>> {
 
@@ -639,6 +654,9 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class EntrySetIterator.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class EntrySetIterator<K, V> extends AbstractIteratorDecorator<Map.Entry<K, V>> {
 
@@ -684,6 +702,9 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class MapEntry.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class MapEntry<K, V> extends AbstractMapEntryDecorator<K, V> {
 
@@ -715,6 +736,9 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
 
     /**
      * Inner class MapIterator.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class BidiMapIterator<K, V> implements MapIterator<K, V>, ResettableIterator<K> {
 

--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -231,6 +231,9 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
 
     /**
      * Internal sorted map view.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class ViewMap<K, V> extends AbstractSortedMapDecorator<K, V> {
         /**
@@ -293,6 +296,9 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
 
     /**
      * Inner class MapIterator.
+     *
+     * @param <K> the type of the keys.
+     * @param <V> the type of the values.
      */
     protected static class BidiOrderedMapIterator<K, V> implements OrderedMapIterator<K, V>, ResettableIterator<K> {
 

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -272,10 +272,10 @@ public final class ArrayCountingBloomFilter implements CountingBloomFilter {
     }
 
     @Override
-    public int getMaxInsert(CellProducer cellProducer) {
-        int[] max = {Integer.MAX_VALUE};
+    public int getMaxInsert(final CellProducer cellProducer) {
+        final int[] max = {Integer.MAX_VALUE};
         cellProducer.forEachCell( (x, y) -> {
-            int count = cells[x] / y;
+            final int count = cells[x] / y;
             if (count < max[0]) {
                 max[0] = count;
             }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -231,14 +231,14 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
      * @see Shape
      */
     default int estimateN() {
-        double d = getShape().estimateN(cardinality());
+        final double d = getShape().estimateN(cardinality());
         if (Double.isInfinite(d)) {
             return Integer.MAX_VALUE;
         }
         if (Double.isNaN(d)) {
             throw new IllegalArgumentException("Cardinality too large: " + cardinality());
         }
-        long l = Math.round(d);
+        final long l = Math.round(d);
         return l > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) l;
     }
 
@@ -283,8 +283,8 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
      */
     default int estimateIntersection(final BloomFilter other) {
         Objects.requireNonNull(other, "other");
-        double eThis = getShape().estimateN(cardinality());
-        double eOther = getShape().estimateN(other.cardinality());
+        final double eThis = getShape().estimateN(cardinality());
+        final double eOther = getShape().estimateN(other.cardinality());
         if (Double.isInfinite(eThis) && Double.isInfinite(eOther)) {
             // if both are infinite the union is infinite and we return Integer.MAX_VALUE
             return Integer.MAX_VALUE;
@@ -296,9 +296,9 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
         } else if (Double.isInfinite(eOther)) {
             estimate = Math.round(eThis);
         } else {
-            BloomFilter union = this.copy();
+            final BloomFilter union = this.copy();
             union.merge(other);
-            double eUnion = getShape().estimateN(union.cardinality());
+            final double eUnion = getShape().estimateN(union.cardinality());
             if (Double.isInfinite(eUnion)) {
                 throw new IllegalArgumentException("The estimated N for the union of the filters is infinite");
             }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/CellProducer.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/CellProducer.java
@@ -95,8 +95,8 @@ public interface CellProducer extends IndexProducer {
             private void populate() {
                 if (counterCells.isEmpty()) {
                     producer.forEachIndex( idx -> {
-                        CounterCell cell = new CounterCell(idx, 1);
-                        CounterCell counter = counterCells.get(cell);
+                        final CounterCell cell = new CounterCell(idx, 1);
+                        final CounterCell counter = counterCells.get(cell);
                         if (counter == null) {
                             counterCells.put(cell, cell);
                         } else {
@@ -114,9 +114,9 @@ public interface CellProducer extends IndexProducer {
             }
 
             @Override
-            public boolean forEachCell(CellConsumer consumer) {
+            public boolean forEachCell(final CellConsumer consumer) {
                 populate();
-                for (CounterCell cell : counterCells.values()) {
+                for (final CounterCell cell : counterCells.values()) {
                     if (!consumer.test(cell.idx, cell.count)) {
                         return false;
                     }
@@ -131,13 +131,13 @@ public interface CellProducer extends IndexProducer {
                 final int idx;
                 int count;
 
-                CounterCell(int idx, int count) {
+                CounterCell(final int idx, final int count) {
                     this.idx = idx;
                     this.count = count;
                 }
 
                 @Override
-                public int compareTo(CounterCell other) {
+                public int compareTo(final CounterCell other) {
                     return Integer.compare(idx, other.idx);
                 }
             }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/CountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/CountingBloomFilter.java
@@ -91,7 +91,7 @@ public interface CountingBloomFilter extends BloomFilter, CellProducer {
      * @param bloomFilter the Bloom filter the check for.
      * @return the maximum number of times the Bloom filter could have been inserted.
      */
-    default int getMaxInsert(BloomFilter bloomFilter) {
+    default int getMaxInsert(final BloomFilter bloomFilter) {
         return getMaxInsert((BitMapProducer) bloomFilter);
     }
 
@@ -104,7 +104,7 @@ public interface CountingBloomFilter extends BloomFilter, CellProducer {
      * @return the maximum number of times the IndexProducer could have been inserted.
      * @see #getMaxInsert(CellProducer)
      */
-    default int getMaxInsert(IndexProducer idxProducer) {
+    default int getMaxInsert(final IndexProducer idxProducer) {
         return getMaxInsert(CellProducer.from(idxProducer.uniqueIndices()) );
     }
 
@@ -121,7 +121,7 @@ public interface CountingBloomFilter extends BloomFilter, CellProducer {
      * @param hasher the Hasher to provide the indices.
      * @return the maximum number of times the hasher could have been inserted.
      */
-    default int getMaxInsert(Hasher hasher) {
+    default int getMaxInsert(final Hasher hasher) {
         return getMaxInsert(hasher.indices(getShape()));
     }
 
@@ -131,12 +131,12 @@ public interface CountingBloomFilter extends BloomFilter, CellProducer {
      * @param bitMapProducer the BitMapProducer to provide the indices.
      * @return the maximum number of times the BitMapProducer could have been inserted.
      */
-    default int getMaxInsert(BitMapProducer bitMapProducer) {
+    default int getMaxInsert(final BitMapProducer bitMapProducer) {
         if (!contains(bitMapProducer)) {
             return 0;
         }
-        long[] bitMaps = bitMapProducer.asBitMapArray();
-        int[] max = { Integer.MAX_VALUE };
+        final long[] bitMaps = bitMapProducer.asBitMapArray();
+        final int[] max = { Integer.MAX_VALUE };
         forEachCell((x, y) -> {
             if ((bitMaps[BitMap.getLongIndex(x)] & BitMap.getLongBit(x)) != 0) {
                 max[0] = max[0] <= y ? max[0] : y;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/CountingLongPredicate.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/CountingLongPredicate.java
@@ -25,7 +25,7 @@ import java.util.function.LongPredicate;
  * execute the @code{text} with a zero value for each remaining @{code idx} value.
  */
 class CountingLongPredicate implements LongPredicate {
-    private int idx = 0;
+    private int idx;
     private final long[] ary;
     private final LongBiPredicate func;
 

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/IndexProducer.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/IndexProducer.java
@@ -131,7 +131,7 @@ public interface IndexProducer {
                 return size == data.length ? data : Arrays.copyOf(data, size);
             }
         }
-        Indices indices = new Indices();
+        final Indices indices = new Indices();
         forEachIndex(indices::add);
         return indices.toArray();
     }
@@ -158,7 +158,7 @@ public interface IndexProducer {
 
         return new IndexProducer() {
             @Override
-            public boolean forEachIndex(IntPredicate predicate) {
+            public boolean forEachIndex(final IntPredicate predicate) {
                 for (int idx = bitSet.nextSetBit(0); idx >= 0; idx = bitSet.nextSetBit(idx + 1)) {
                     if (!predicate.test(idx)) {
                         return false;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/IndexProducer.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/IndexProducer.java
@@ -82,7 +82,7 @@ public interface IndexProducer {
         Objects.requireNonNull(producer, "producer");
         return consumer -> {
             final LongPredicate longPredicate = new LongPredicate() {
-                int wordIdx = 0;
+                int wordIdx;
 
                 @Override
                 public boolean test(long word) {

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/IndexUtils.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/IndexUtils.java
@@ -38,7 +38,7 @@ final class IndexUtils {
      * @param index the index to add at.
      * @return the array or a newly allocated copy of the array.
      */
-    static int[] ensureCapacityForAdd(int[] array, int index) {
+    static int[] ensureCapacityForAdd(final int[] array, final int index) {
         if (index >= array.length) {
             return Arrays.copyOf(array, (int) Math.min(IndexUtils.MAX_ARRAY_SIZE, Math.max(array.length * 2L, index + 1)));
         }

--- a/src/main/java/org/apache/commons/collections4/functors/SwitchClosure.java
+++ b/src/main/java/org/apache/commons/collections4/functors/SwitchClosure.java
@@ -114,7 +114,6 @@ public class SwitchClosure<E> implements Closure<E>, Serializable {
      * @param closures  matching array of closures, no nulls
      * @param defaultClosure  the closure to use if no match, null means nop
      */
-    @SuppressWarnings("unchecked")
     private SwitchClosure(final boolean clone, final Predicate<? super E>[] predicates,
                           final Closure<? super E>[] closures, final Closure<? super E> defaultClosure) {
         iPredicates = clone ? FunctorUtils.copy(predicates) : predicates;

--- a/src/main/java/org/apache/commons/collections4/functors/SwitchTransformer.java
+++ b/src/main/java/org/apache/commons/collections4/functors/SwitchTransformer.java
@@ -124,7 +124,6 @@ public class SwitchTransformer<I, O> implements Transformer<I, O>, Serializable 
      * @param transformers  matching array of transformers, no nulls
      * @param defaultTransformer  the transformer to use if no match, null means return null
      */
-    @SuppressWarnings("unchecked")
     private SwitchTransformer(final boolean clone, final Predicate<? super I>[] predicates,
                              final Transformer<? super I, ? extends O>[] transformers,
                              final Transformer<? super I, ? extends O> defaultTransformer) {

--- a/src/main/java/org/apache/commons/collections4/iterators/AbstractIteratorDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/AbstractIteratorDecorator.java
@@ -22,7 +22,9 @@ import java.util.Iterator;
  * Provides basic behavior for decorating an iterator with extra functionality.
  * <p>
  * All methods are forwarded to the decorated iterator.
+ * </p>
  *
+ * @param <E> the type of the iterator being decorated.
  * @since 3.0
  */
 public abstract class AbstractIteratorDecorator<E> extends AbstractUntypedIteratorDecorator<E, E> {

--- a/src/main/java/org/apache/commons/collections4/iterators/AbstractListIteratorDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/AbstractListIteratorDecorator.java
@@ -23,7 +23,9 @@ import java.util.Objects;
  * Provides basic behavior for decorating a list iterator with extra functionality.
  * <p>
  * All methods are forwarded to the decorated list iterator.
+ * </p>
  *
+ * @param <E> the type of elements in this iterator.
  * @since 3.0
  */
 public class AbstractListIteratorDecorator<E> implements ListIterator<E> {

--- a/src/main/java/org/apache/commons/collections4/iterators/AbstractUntypedIteratorDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/AbstractUntypedIteratorDecorator.java
@@ -20,10 +20,13 @@ import java.util.Iterator;
 import java.util.Objects;
 
 /**
- * Provides basic behavior for decorating an iterator with extra functionality
- * without committing the generic type of the Iterator implementation.
+ * Provides basic behavior for decorating an iterator with extra functionality without committing the generic type of the Iterator implementation.
  * <p>
  * All methods are forwarded to the decorated iterator.
+ * </p>
+ *
+ * @param <I> the type of the iterator being decorated.
+ * @param <O> the type of elements returned by this iterator.
  *
  * @since 4.0
  */

--- a/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
@@ -46,6 +46,7 @@ import java.util.Queue;
  * removed and {@link #size()} will return the number of remaining iterators in
  * the queue.
  *
+ * @param <E> the type of elements in this iterator.
  * @since 2.1
  */
 public class IteratorChain<E> implements Iterator<E> {

--- a/src/main/java/org/apache/commons/collections4/iterators/LazyIteratorChain.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/LazyIteratorChain.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
  * NOTE: The LazyIteratorChain may contain no iterators. In this case the class will
  * function as an empty iterator.
  *
+ * @param <E> the type of elements in this iterator.
  * @since 4.0
  */
 public abstract class LazyIteratorChain<E> implements Iterator<E> {

--- a/src/main/java/org/apache/commons/collections4/iterators/ListIteratorWrapper.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/ListIteratorWrapper.java
@@ -43,6 +43,7 @@ import org.apache.commons.collections4.ResettableListIterator;
  * <p>
  * This class implements ResettableListIterator from Commons Collections 3.2.
  *
+ * @param <E> the type of elements in this iterator.
  * @since 2.1
  */
 public class ListIteratorWrapper<E> implements ResettableListIterator<E> {

--- a/src/main/java/org/apache/commons/collections4/list/AbstractLinkedList.java
+++ b/src/main/java/org/apache/commons/collections4/list/AbstractLinkedList.java
@@ -41,6 +41,7 @@ import org.apache.commons.collections4.OrderedIterator;
  * is here.
  * </p>
  *
+ * @param <E> the type of elements in this list
  * @since 3.0
  */
 public abstract class AbstractLinkedList<E> implements List<E> {
@@ -745,6 +746,8 @@ public abstract class AbstractLinkedList<E> implements List<E> {
 
     /**
      * A list iterator over the linked list.
+     *
+     * @param <E> the type of elements in this iterator.
      */
     protected static class LinkedListIterator<E> implements ListIterator<E>, OrderedIterator<E> {
 
@@ -904,6 +907,8 @@ public abstract class AbstractLinkedList<E> implements List<E> {
 
     /**
      * A list iterator over the linked sub list.
+     *
+     * @param <E> the type of elements in this iterator.
      */
     protected static class LinkedSubListIterator<E> extends LinkedListIterator<E> {
 
@@ -947,6 +952,8 @@ public abstract class AbstractLinkedList<E> implements List<E> {
 
     /**
      * The sublist implementation for AbstractLinkedList.
+     *
+     * @param <E> the type of elements in this list.
      */
     protected static class LinkedSubList<E> extends AbstractList<E> {
         /** The main list */

--- a/src/main/java/org/apache/commons/collections4/list/CursorableLinkedList.java
+++ b/src/main/java/org/apache/commons/collections4/list/CursorableLinkedList.java
@@ -392,6 +392,8 @@ public class CursorableLinkedList<E> extends AbstractLinkedList<E> implements Se
     /**
      * An extended {@code ListIterator} that allows concurrent changes to
      * the underlying list.
+     *
+     * @param <E> the type of elements in this cursor.
      */
     public static class Cursor<E> extends AbstractLinkedList.LinkedListIterator<E> {
         /** Is the cursor valid (not closed) */
@@ -562,6 +564,7 @@ public class CursorableLinkedList<E> extends AbstractLinkedList<E> implements Se
     /**
      * A cursor for the sublist based on LinkedSubListIterator.
      *
+     * @param <E> the type of elements in this cursor.
      * @since 3.2
      */
     protected static class SubCursor<E> extends Cursor<E> {

--- a/src/main/java/org/apache/commons/collections4/map/MultiValueMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/MultiValueMap.java
@@ -541,7 +541,7 @@ public class MultiValueMap<K, V> extends AbstractMapDecorator<K, Object> impleme
     /**
      * Inner class that provides a simple reflection factory.
      */
-    private static class ReflectionFactory<T extends Collection<?>> implements Factory<T>, Serializable {
+    private static final class ReflectionFactory<T extends Collection<?>> implements Factory<T>, Serializable {
 
         /** Serialization version */
         private static final long serialVersionUID = 2986114157496788874L;

--- a/src/main/java/org/apache/commons/collections4/map/StaticBucketMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/StaticBucketMap.java
@@ -177,7 +177,7 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
         int cnt = 0;
 
         for (int i = 0; i < buckets.length; i++) {
-            synchronized(locks[i]) {
+            synchronized (locks[i]) {
                 cnt += locks[i].size;
             }
         }

--- a/src/main/java/org/apache/commons/collections4/multimap/HashSetValuedHashMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/HashSetValuedHashMap.java
@@ -21,10 +21,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
-
 import org.apache.commons.collections4.MultiValuedMap;
+
 
 /**
  * Implements a {@code SetValuedMap}, using a {@link HashMap} to provide data
@@ -113,8 +113,8 @@ public class HashSetValuedHashMap<K, V> extends AbstractSetValuedMap<K, V>
     }
 
     @Override
-    protected HashSet<V> createCollection() {
-        return new HashSet<>(initialSetCapacity);
+    protected LinkedHashSet<V> createCollection() {
+        return new LinkedHashSet<>(initialSetCapacity);
     }
 
     private void writeObject(final ObjectOutputStream oos) throws IOException {

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -147,7 +147,7 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
     /**
      * Inner class iterator for the MultiSet.
      */
-    private static class MapBasedMultiSetIterator<E> implements Iterator<E> {
+    private static final class MapBasedMultiSetIterator<E> implements Iterator<E> {
         private final AbstractMapMultiSet<E> parent;
         private final Iterator<Map.Entry<E, MutableInteger>> entryIterator;
         private Map.Entry<E, MutableInteger> current;

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMultiSet.java
@@ -122,7 +122,7 @@ public abstract class AbstractMultiSet<E> extends AbstractCollection<E> implemen
     /**
      * Inner class iterator for the MultiSet.
      */
-    private static class MultiSetIterator<E> implements Iterator<E> {
+    private static final class MultiSetIterator<E> implements Iterator<E> {
         private final AbstractMultiSet<E> parent;
         private final Iterator<Entry<E>> entryIterator;
         private Entry<E> current;

--- a/src/main/java/org/apache/commons/collections4/properties/PropertiesFactory.java
+++ b/src/main/java/org/apache/commons/collections4/properties/PropertiesFactory.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
  */
 public class PropertiesFactory extends AbstractPropertiesFactory<Properties> {
 
-    private static class EmptyProperties extends Properties {
+    private static final class EmptyProperties extends Properties {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/apache/commons/collections4/sequence/SequencesComparator.java
+++ b/src/main/java/org/apache/commons/collections4/sequence/SequencesComparator.java
@@ -292,7 +292,7 @@ public class SequencesComparator<T> {
      * This class is a simple placeholder to hold the end part of a path
      * under construction in a {@link SequencesComparator SequencesComparator}.
      */
-    private static class Snake {
+    private static final class Snake {
 
         /** Start index. */
         private final int start;

--- a/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
+++ b/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
@@ -1257,7 +1257,7 @@ public abstract class AbstractPatriciaTrie<K, V> extends AbstractBitwiseTrie<K, 
      * wise there's no difference (except for the need to load the
      * {@link Reference} Class but that happens only once).
      */
-    private static class Reference<E> {
+    private static final class Reference<E> {
 
         private E item;
 

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -155,7 +155,7 @@ public class BulkTest implements Cloneable {
     /**
      *  the name of the simple test method
      */
-    private String name;
+    private final String name;
 
     /**
      *  Constructs a new {@code BulkTest} instance that will run the

--- a/src/test/java/org/apache/commons/collections4/ClosureUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ClosureUtilsTest.java
@@ -45,7 +45,7 @@ public class ClosureUtilsTest {
     private static final Object cString = "Hello";
 
     static class MockClosure<T> implements Closure<T> {
-        int count = 0;
+        int count;
 
         @Override
         public void execute(final T object) {
@@ -58,7 +58,7 @@ public class ClosureUtilsTest {
     }
 
     static class MockTransformer<T> implements Transformer<T, T> {
-        int count = 0;
+        int count;
 
         @Override
         public T transform(final T object) {

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -689,8 +689,7 @@ public class CollectionUtilsTest extends MockTestCase {
         assertEquals(2, CollectionUtils.get((Object) collectionA.iterator(), 2));
         final Map<Integer, Integer> map = CollectionUtils.getCardinalityMap(collectionA);
         // Test assumes a defined iteration order so convert to a LinkedHashMap
-        final Map<Integer, Integer> linkedMap = new LinkedHashMap<>();
-        linkedMap.putAll(map);
+        final Map<Integer, Integer> linkedMap = new LinkedHashMap<>(map);
         assertEquals(linkedMap.entrySet().iterator().next(), CollectionUtils.get((Object) linkedMap, 0));
     }
 

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -69,54 +69,54 @@ public class CollectionUtilsTest extends MockTestCase {
     /**
      * Collection of {@link Integer}s
      */
-    private List<Integer> collectionA = null;
+    private List<Integer> collectionA;
 
     /**
      * Collection of {@link Long}s
      */
-    private List<Long> collectionB = null;
+    private List<Long> collectionB;
 
     /**
      * Collection of {@link Integer}s that are equivalent to the Longs in
      * collectionB.
      */
-    private Collection<Integer> collectionC = null;
+    private Collection<Integer> collectionC;
 
     /**
      * Sorted Collection of {@link Integer}s
      */
-    private Collection<Integer> collectionD = null;
+    private Collection<Integer> collectionD;
 
     /**
      * Sorted Collection of {@link Integer}s
      */
-    private Collection<Integer> collectionE = null;
+    private Collection<Integer> collectionE;
 
     /**
      * Collection of {@link Integer}s, bound as {@link Number}s
      */
-    private Collection<Number> collectionA2 = null;
+    private Collection<Number> collectionA2;
 
     /**
      * Collection of {@link Long}s, bound as {@link Number}s
      */
-    private Collection<Number> collectionB2 = null;
+    private Collection<Number> collectionB2;
 
     /**
      * Collection of {@link Integer}s (cast as {@link Number}s) that are
      * equivalent to the Longs in collectionB.
      */
-    private Collection<Number> collectionC2 = null;
+    private Collection<Number> collectionC2;
 
-    private Iterable<Integer> iterableA = null;
+    private Iterable<Integer> iterableA;
 
-    private Iterable<Long> iterableB = null;
+    private Iterable<Long> iterableB;
 
-    private Iterable<Integer> iterableC = null;
+    private Iterable<Integer> iterableC;
 
-    private Iterable<Number> iterableA2 = null;
+    private Iterable<Number> iterableA2;
 
-    private Iterable<Number> iterableB2 = null;
+    private Iterable<Number> iterableB2;
 
     private final Collection<Integer> emptyCollection = new ArrayList<>(1);
 

--- a/src/test/java/org/apache/commons/collections4/FactoryUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/FactoryUtilsTest.java
@@ -168,7 +168,7 @@ public class FactoryUtilsTest {
     }
 
     public static class Mock3 {
-        private static int cCounter = 0;
+        private static int cCounter;
         private final int iVal;
         public Mock3() {
             iVal = cCounter++;

--- a/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
@@ -47,27 +47,27 @@ public class FluentIterableTest {
     /**
      * Iterable of {@link Integer}s
      */
-    private Iterable<Integer> iterableA = null;
+    private Iterable<Integer> iterableA;
 
     /**
      * Iterable of {@link Long}s
      */
-    private Iterable<Long> iterableB = null;
+    private Iterable<Long> iterableB;
 
     /**
      * Collection of even {@link Integer}s
      */
-    private Iterable<Integer> iterableEven = null;
+    private Iterable<Integer> iterableEven;
 
     /**
      * Collection of odd {@link Integer}s
      */
-    private Iterable<Integer> iterableOdd = null;
+    private Iterable<Integer> iterableOdd;
 
     /**
      * An empty Iterable.
      */
-    private Iterable<Integer> emptyIterable = null;
+    private Iterable<Integer> emptyIterable;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/apache/commons/collections4/GuavaTestlibTest.java
+++ b/src/test/java/org/apache/commons/collections4/GuavaTestlibTest.java
@@ -22,6 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
 import org.apache.commons.collections4.list.TreeList;
 import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.collections4.map.LRUMap;
@@ -37,10 +41,6 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.Feature;
 import com.google.common.collect.testing.features.ListFeature;
 import com.google.common.collect.testing.features.MapFeature;
-
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 /**
  * This test uses Google's Guava Testlib testing libraries to validate the

--- a/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
@@ -50,17 +50,17 @@ public class IterableUtilsTest {
     /**
      * Iterable of {@link Integer}s
      */
-    private Iterable<Integer> iterableA = null;
+    private Iterable<Integer> iterableA;
 
     /**
      * Iterable of {@link Long}s
      */
-    private Iterable<Long> iterableB = null;
+    private Iterable<Long> iterableB;
 
     /**
      * An empty Iterable.
      */
-    private Iterable<Integer> emptyIterable = null;
+    private Iterable<Integer> emptyIterable;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
@@ -70,21 +70,21 @@ public class IteratorUtilsTest {
     /**
      * Collection of {@link Integer}s
      */
-    private List<Integer> collectionA = null;
+    private List<Integer> collectionA;
 
     /**
      * Collection of even {@link Integer}s
      */
-    private List<Integer> collectionEven = null;
+    private List<Integer> collectionEven;
 
     /**
      * Collection of odd {@link Integer}s
      */
-    private List<Integer> collectionOdd = null;
+    private List<Integer> collectionOdd;
 
     private final Collection<Integer> emptyCollection = new ArrayList<>(1);
 
-    private Iterable<Integer> iterableA = null;
+    private Iterable<Integer> iterableA;
 
     /**
      * Creates a NodeList containing the specified nodes.

--- a/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
@@ -437,8 +437,8 @@ public class IteratorUtilsTest {
     @Test
     public void testChainedIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
-        assertTrue(IteratorUtils.chainedIterator(ie) instanceof Iterator, "create instance fail");
+        final Iterator iterator = arrayList.iterator();
+        assertTrue(IteratorUtils.chainedIterator(iterator) instanceof Iterator, "create instance fail");
         final Collection<Iterator<?>> coll = new ArrayList();
         assertTrue(IteratorUtils.chainedIterator(coll) instanceof Iterator, "create instance fail");
     }
@@ -649,9 +649,9 @@ public class IteratorUtilsTest {
     @Test
     public void testFilteredIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
+        final Iterator iterator = arrayList.iterator();
         assertAll(
-                () -> assertThrows(NullPointerException.class, () -> IteratorUtils.filteredIterator(ie, null)),
+                () -> assertThrows(NullPointerException.class, () -> IteratorUtils.filteredIterator(iterator, null)),
                 () -> assertThrows(NullPointerException.class, () -> IteratorUtils.filteredIterator(null, null))
         );
     }
@@ -805,7 +805,7 @@ public class IteratorUtilsTest {
         arrayList.add("test");
         final Collection coll = new ArrayList();
         coll.add("test");
-        final Iterator ie = arrayList.iterator();
+        final Iterator iterator = arrayList.iterator();
         assertTrue(IteratorUtils.loopingIterator(coll) instanceof ResettableIterator, "create instance fail");
         assertThrows(NullPointerException.class, () -> IteratorUtils.loopingIterator(null));
     }
@@ -814,7 +814,7 @@ public class IteratorUtilsTest {
     public void testLoopingListIterator() {
         final ArrayList arrayList = new ArrayList();
         arrayList.add("test");
-        final Iterator ie = arrayList.iterator();
+        final Iterator iterator = arrayList.iterator();
         assertTrue(IteratorUtils.loopingListIterator(arrayList) instanceof ResettableIterator, "create instance fail");
         assertThrows(NullPointerException.class, () -> IteratorUtils.loopingListIterator(null));
     }
@@ -880,16 +880,16 @@ public class IteratorUtilsTest {
     @Test
     public void testPeekingIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
-        assertTrue(IteratorUtils.peekingIterator(ie) instanceof Iterator, "create instance fail");
+        final Iterator iterator = arrayList.iterator();
+        assertTrue(IteratorUtils.peekingIterator(iterator) instanceof Iterator, "create instance fail");
         assertThrows(NullPointerException.class, () -> IteratorUtils.peekingIterator(null));
     }
 
     @Test
     public void testPushBackIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
-        assertTrue(IteratorUtils.pushbackIterator(ie) instanceof Iterator, "create instance fail");
+        final Iterator iterator = arrayList.iterator();
+        assertTrue(IteratorUtils.pushbackIterator(iterator) instanceof Iterator, "create instance fail");
         assertThrows(NullPointerException.class, () -> IteratorUtils.pushbackIterator(null));
     }
 
@@ -974,9 +974,9 @@ public class IteratorUtilsTest {
     @Test
     public void testTransformedIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
+        final Iterator iterator = arrayList.iterator();
         assertAll(
-                () -> assertThrows(NullPointerException.class, () -> IteratorUtils.transformedIterator(ie, null)),
+                () -> assertThrows(NullPointerException.class, () -> IteratorUtils.transformedIterator(iterator, null)),
                 () -> assertThrows(NullPointerException.class, () -> IteratorUtils.transformedIterator(null, null))
         );
     }
@@ -1103,17 +1103,17 @@ public class IteratorUtilsTest {
     @Test
     public void testUnmodifiableMapIterator() {
         final Set<?> set = new LinkedHashSet<>();
-        final MapIterator ie = new EntrySetToMapIteratorAdapter(set);
-        assertTrue(IteratorUtils.unmodifiableMapIterator(ie) instanceof MapIterator, "create instance fail");
+        final MapIterator iterator = new EntrySetToMapIteratorAdapter(set);
+        assertTrue(IteratorUtils.unmodifiableMapIterator(iterator) instanceof MapIterator, "create instance fail");
         assertThrows(NullPointerException.class, () -> IteratorUtils.unmodifiableMapIterator(null));
     }
 
     @Test
     public void testZippingIterator() {
         final ArrayList arrayList = new ArrayList();
-        final Iterator ie = arrayList.iterator();
-        assertTrue(IteratorUtils.zippingIterator(ie, ie, ie) instanceof ZippingIterator, "create instance fail");
-        assertTrue(IteratorUtils.zippingIterator(ie, ie) instanceof ZippingIterator, "create instance fail");
+        final Iterator iterator = arrayList.iterator();
+        assertTrue(IteratorUtils.zippingIterator(iterator, iterator, iterator) instanceof ZippingIterator, "create instance fail");
+        assertTrue(IteratorUtils.zippingIterator(iterator, iterator) instanceof ZippingIterator, "create instance fail");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -344,7 +344,7 @@ public class ListUtilsTest {
 
     @Test
     public void testPredicatedList() {
-        final Predicate<Object> predicate = o -> o instanceof String;
+        final Predicate<Object> predicate = String.class::isInstance;
         final List<Object> list = ListUtils.predicatedList(new ArrayList<>(), predicate);
         assertTrue(list instanceof PredicatedList, "returned object should be a PredicatedList");
         assertAll(

--- a/src/test/java/org/apache/commons/collections4/MapPerformance.java
+++ b/src/test/java/org/apache/commons/collections4/MapPerformance.java
@@ -127,7 +127,7 @@ public class MapPerformance {
         System.out.println(name + (endMillis - startMillis));
     }
 
-    private static class DummyMap<K, V> implements Map<K, V> {
+    private static final class DummyMap<K, V> implements Map<K, V> {
         @Override
         public void clear() {
         }

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -62,7 +62,7 @@ public class MapUtilsTest {
     private static final String TWO = "Two";
 
     public Predicate<Object> getPredicate() {
-        return o -> o instanceof String;
+        return String.class::isInstance;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/SetUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/SetUtilsTest.java
@@ -208,7 +208,7 @@ public class SetUtilsTest {
 
     @Test
     public void testpredicatedSet() {
-        final Predicate<Object> predicate = o -> o instanceof String;
+        final Predicate<Object> predicate = String.class::isInstance;
         final Set<Object> set = SetUtils.predicatedSet(new HashSet<>(), predicate);
         assertTrue(set instanceof PredicatedSet, "returned object should be a PredicatedSet");
         assertAll(

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -41,7 +41,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
     }
 
     protected Predicate<T> stringPredicate() {
-        return o -> o instanceof String;
+        return String.class::isInstance;
     }
 
     protected Predicate<T> truePredicate = TruePredicate.<T>truePredicate();

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
@@ -42,7 +42,7 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
     }
 
     protected Predicate<T> stringPredicate() {
-        return o -> o instanceof String;
+        return String.class::isInstance;
     }
 
     protected Predicate<T> truePredicate = TruePredicate.<T>truePredicate();

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapDecoratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapDecoratorTest.java
@@ -67,7 +67,7 @@ public class AbstractOrderedBidiMapDecoratorTest<K, V>
      */
     private static final class TestOrderedBidiMap<K, V> extends AbstractOrderedBidiMapDecorator<K, V> {
 
-        private TestOrderedBidiMap<V, K> inverse = null;
+        private TestOrderedBidiMap<V, K> inverse;
 
         TestOrderedBidiMap() {
             super(new DualTreeBidiMap<>());

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
@@ -97,7 +97,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         }
     }
 
-    private static class IntegerComparator implements Comparator<Integer>, Serializable{
+    private static final class IntegerComparator implements Comparator<Integer>, Serializable{
         private static final long serialVersionUID = 1L;
         @Override
         public int compare(final Integer o1, final Integer o2) {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBitMapProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBitMapProducerTest.java
@@ -106,14 +106,12 @@ public abstract class AbstractBitMapProducerTest {
 
         // test where the created producer does not process all records because the predicate function
         // returns false before the processing is completed.
-        int[] limit = new int[1];
+        final int[] limit = new int[1];
         final LongBiPredicate shortFunc =  (x, y) -> {
             limit[0]++;
             return limit[0] < 2;
         };
-        final BitMapProducer shortProducer = l -> {
-            return true;
-        };
+        final BitMapProducer shortProducer = l -> true;
         assertFalse(createProducer().forEachBitMapPair(shortProducer, shortFunc));
     }
 

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
 
     @Test
     public void testMergeWithBitMapProducer() {
-        int bitMapCount = BitMap.numberOfBitMaps(getTestShape().getNumberOfBits());
+        final int bitMapCount = BitMap.numberOfBitMaps(getTestShape().getNumberOfBits());
         for (int i = 0; i < 5; i++) {
             final long[] values = new long[bitMapCount];
             for (final int idx : DefaultIndexProducerTest.generateIntArray(getTestShape().getNumberOfHashFunctions(), getTestShape().getNumberOfBits())) {
@@ -134,7 +134,7 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
             assertTrue(lst.isEmpty());
         }
         // values too large
-        long[] values = new long[bitMapCount];
+        final long[] values = new long[bitMapCount];
         Arrays.fill(values, Long.MAX_VALUE);
         final BitMapProducer badProducer = BitMapProducer.fromBitMapArray(values);
         final BloomFilter bf = createEmptyFilter(getTestShape());
@@ -162,11 +162,11 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         // value to large
         final BloomFilter f1 = createEmptyFilter(getTestShape());
         assertThrows(IllegalArgumentException.class,
-                () -> f1.merge(IndexProducer.fromIndexArray(new int[] {getTestShape().getNumberOfBits()})));
+                () -> f1.merge(IndexProducer.fromIndexArray(getTestShape().getNumberOfBits())));
         // negative value
         final BloomFilter f2 = createEmptyFilter(getTestShape());
         assertThrows(IllegalArgumentException.class,
-                () -> f2.merge(IndexProducer.fromIndexArray(new int[] {-1})));
+                () -> f2.merge(IndexProducer.fromIndexArray(-1)));
     }
 
     @Test
@@ -218,12 +218,12 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
 
     @Test
     public final void testNegativeIntersection() {
-        IndexProducer p1 = IndexProducer.fromIndexArray(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 20, 26, 28, 30, 32, 34, 35, 36, 37, 39, 40, 41, 42, 43, 45, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71);
-        IndexProducer p2 = IndexProducer.fromIndexArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27);
+        final IndexProducer p1 = IndexProducer.fromIndexArray(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 20, 26, 28, 30, 32, 34, 35, 36, 37, 39, 40, 41, 42, 43, 45, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71);
+        final IndexProducer p2 = IndexProducer.fromIndexArray(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27);
 
-        BloomFilter filter1 = createEmptyFilter(Shape.fromKM(17, 72));
+        final BloomFilter filter1 = createEmptyFilter(Shape.fromKM(17, 72));
         filter1.merge(p1);
-        BloomFilter filter2 = createEmptyFilter(Shape.fromKM(17, 72));
+        final BloomFilter filter2 = createEmptyFilter(Shape.fromKM(17, 72));
         filter2.merge(p2);
         assertEquals(0, filter1.estimateIntersection(filter2));
     }
@@ -249,9 +249,9 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         assertEquals(0, bf.estimateIntersection(bf4));
         assertEquals(0, bf4.estimateIntersection(bf));
 
-        int midPoint = getTestShape().getNumberOfBits() / 2;
-        BloomFilter bf5 = TestingHashers.populateRange(createEmptyFilter(getTestShape()), 0, midPoint);
-        BloomFilter bf6 = TestingHashers.populateRange(createEmptyFilter(getTestShape()), midPoint+1, getTestShape().getNumberOfBits()-1);
+        final int midPoint = getTestShape().getNumberOfBits() / 2;
+        final BloomFilter bf5 = TestingHashers.populateRange(createEmptyFilter(getTestShape()), 0, midPoint);
+        final BloomFilter bf6 = TestingHashers.populateRange(createEmptyFilter(getTestShape()), midPoint+1, getTestShape().getNumberOfBits()-1);
         assertThrows(IllegalArgumentException.class, () -> bf5.estimateIntersection(bf6));
 
         // infinite with infinite
@@ -371,8 +371,8 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         assertThrows(IllegalArgumentException.class, () -> bf1.merge(new BadHasher(-1)));
 
         // test error when bloom filter returns values out of range
-        Shape s = Shape.fromKM(getTestShape().getNumberOfHashFunctions(), getTestShape().getNumberOfBits() * 3);
-        Hasher h = new IncrementingHasher(getTestShape().getNumberOfBits() * 2, 1);
+        final Shape s = Shape.fromKM(getTestShape().getNumberOfHashFunctions(), getTestShape().getNumberOfBits() * 3);
+        final Hasher h = new IncrementingHasher(getTestShape().getNumberOfBits() * 2, 1);
         final BloomFilter bf5 = new SimpleBloomFilter(s);
         bf5.merge(h);
         assertThrows(IllegalArgumentException.class, () -> bf1.merge(bf5));
@@ -441,7 +441,7 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         IndexProducer producer;
 
         public BadHasher(final int value) {
-            this.producer = IndexProducer.fromIndexArray(new int[] {value});
+            this.producer = IndexProducer.fromIndexArray(value);
         }
 
         @Override

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractCellProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractCellProducerTest.java
@@ -106,10 +106,10 @@ public abstract class AbstractCellProducerTest extends AbstractIndexProducerTest
 
     @Test
     public void testForEachCellValues() {
-        int[] expectedIdx = getExpectedIndices();
-        int[] expectedValue = getExpectedValues();
+        final int[] expectedIdx = getExpectedIndices();
+        final int[] expectedValue = getExpectedValues();
         assertEquals(expectedIdx.length, expectedValue.length, "expected index length and value length do not match");
-        int[] idx = {0};
+        final int[] idx = {0};
         createProducer().forEachCell((i, j) -> {
             assertEquals(expectedIdx[idx[0]], i, "bad index at " + idx[0]);
             assertEquals(expectedValue[idx[0]], j, "bad value at " + idx[0]);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractCountingBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractCountingBloomFilterTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
 
     private static final long bigHashValue = 0xffffffeL;
 
-    protected final CellProducer getMaximumValueProducer(int maxValue) {
+    protected final CellProducer getMaximumValueProducer(final int maxValue) {
         return consumer -> {
             for (int i = 1; i < 18; i++) {
                 if (!consumer.test(i, maxValue)) {
@@ -194,7 +194,7 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
         assertCounts(bf3, new int[] {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
         assertThrows(IllegalArgumentException.class, () -> bf3.remove( new BadHasher(-1)));
-        assertThrows(IllegalArgumentException.class, () -> bf3.remove( new BadHasher(getTestShape().getNumberOfBits())));;
+        assertThrows(IllegalArgumentException.class, () -> bf3.remove( new BadHasher(getTestShape().getNumberOfBits())));
     }
 
     /**
@@ -266,7 +266,7 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
         final BitMapProducer bmp2 = BitMapProducer.fromIndexProducer(ip2, getTestShape().getNumberOfBits());
         assertThrows(IllegalArgumentException.class, () -> bf7.remove(bmp2));
         assertThrows(IllegalArgumentException.class, () -> bf7.remove( new BadHasher(-1)));
-        assertThrows(IllegalArgumentException.class, () -> bf7.remove( new BadHasher(getTestShape().getNumberOfBits())));;
+        assertThrows(IllegalArgumentException.class, () -> bf7.remove( new BadHasher(getTestShape().getNumberOfBits())));
     }
 
     @Test
@@ -299,12 +299,12 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
         assertTrue(bf1.forEachCell((x, y) -> false), "Hasher in removes results in value not equal to 0");
     }
 
-    private void verifyMaxInsert(CountingBloomFilter bf, int from1, int from11) {
-        BloomFilter bfFrom0 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
+    private void verifyMaxInsert(final CountingBloomFilter bf, final int from1, final int from11) {
+        final BloomFilter bfFrom0 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
         bfFrom0.merge(new IncrementingHasher(0, 1));
-        BloomFilter bfFrom1 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
+        final BloomFilter bfFrom1 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
         bfFrom1.merge(TestingHashers.FROM1);
-        BloomFilter bfFrom11 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
+        final BloomFilter bfFrom11 = new DefaultBloomFilterTest.SparseDefaultBloomFilter(getTestShape());
         bfFrom11.merge(TestingHashers.FROM11);
 
         assertEquals(0, bf.getMaxInsert(new IncrementingHasher(0, 1)));
@@ -325,7 +325,7 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
 
     @Test
     public void testGetMaxInsert() {
-        CountingBloomFilter bf = createEmptyFilter(getTestShape());
+        final CountingBloomFilter bf = createEmptyFilter(getTestShape());
         verifyMaxInsert(bf, 0, 0);
         bf.merge(TestingHashers.FROM1);
         verifyMaxInsert(bf, 1, 0);
@@ -343,7 +343,7 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
         assertEquals(0, bf.getMaxInsert(new IncrementingHasher(5, 1)));
     }
 
-    private void assertCell3(CountingBloomFilter bf, int value) {
+    private void assertCell3(final CountingBloomFilter bf, final int value) {
         bf.forEachCell((k, v) -> {
             if (k == 3) {
                 assertEquals(value, v, "Mismatch at position 3");
@@ -356,11 +356,11 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
 
     @Test
     public void mergeIncrementsAllCellsTest() {
-        CountingBloomFilter f1 = createEmptyFilter(Shape.fromKM(1, 10));
-        CountingBloomFilter f2 = f1.copy();
-        CountingBloomFilter f3 = f1.copy();
+        final CountingBloomFilter f1 = createEmptyFilter(Shape.fromKM(1, 10));
+        final CountingBloomFilter f2 = f1.copy();
+        final CountingBloomFilter f3 = f1.copy();
         // index producer produces 3 two times.
-        IndexProducer ip = p -> {
+        final IndexProducer ip = p -> {
             p.test(3);
             p.test(3);
             return true;
@@ -376,16 +376,16 @@ public abstract class AbstractCountingBloomFilterTest<T extends CountingBloomFil
 
     @Test
     public void removeDecrementsAllCellsTest() {
-        CountingBloomFilter f1 = createEmptyFilter(Shape.fromKM(1, 10));
-        CellProducer cp = p -> {
+        final CountingBloomFilter f1 = createEmptyFilter(Shape.fromKM(1, 10));
+        final CellProducer cp = p -> {
             p.test(3, 3);
             return true;
         };
         f1.add(cp);
-        CountingBloomFilter f2 = f1.copy();
-        CountingBloomFilter f3 = f1.copy();
+        final CountingBloomFilter f2 = f1.copy();
+        final CountingBloomFilter f3 = f1.copy();
         // index producer produces 3 two times.
-        IndexProducer ip = p -> {
+        final IndexProducer ip = p -> {
             p.test(3);
             p.test(3);
             return true;

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractIndexProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractIndexProducerTest.java
@@ -249,7 +249,7 @@ public abstract class AbstractIndexProducerTest {
 
     @Test
     public void testUniqueReturnsSelf() {
-        IndexProducer expected = createProducer().uniqueIndices();
+        final IndexProducer expected = createProducer().uniqueIndices();
         assertSame(expected, expected.uniqueIndices());
     }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapTest.java
@@ -128,7 +128,7 @@ public class BitMapTest {
      * @param dividend the dividend
      * @param divisor the divisor
      */
-    private void assertMod(long dividend, int divisor) {
+    private void assertMod(final long dividend, final int divisor) {
         assertTrue(divisor > 0 && divisor <= Integer.MAX_VALUE,
             "Incorrect usage. Divisor must be strictly positive.");
         assertEquals((int) Long.remainderUnsigned(dividend, divisor), BitMap.mod(dividend, divisor),

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBitMapProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBitMapProducerTest.java
@@ -91,16 +91,13 @@ public class DefaultBitMapProducerTest extends AbstractBitMapProducerTest {
     @Test
     public void testAsBitMapArrayLargeArray() {
         final long[] expected = generateLongArray(32);
-        BitMapProducer producer = new BitMapProducer() {
-            @Override
-            public boolean forEachBitMap(LongPredicate predicate) {
-                for (long l : expected) {
-                    if (!predicate.test(l)) {
-                        return false;
-                    }
+        final BitMapProducer producer = predicate -> {
+            for (final long l : expected) {
+                if (!predicate.test(l)) {
+                    return false;
                 }
-                return true;
             }
+            return true;
         };
         final long[] ary = producer.asBitMapArray();
         assertArrayEquals(expected, ary);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
@@ -71,15 +71,15 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
     @Test
     public void testEstimateNWithBrokenCardinality() {
         // build a filter
-        BloomFilter filter1 = TestingHashers.populateEntireFilter(new BrokenCardinality(getTestShape()));
+        final BloomFilter filter1 = TestingHashers.populateEntireFilter(new BrokenCardinality(getTestShape()));
         assertThrows(IllegalArgumentException.class, () -> filter1.estimateN());
     }
 
     @Test
     public void testEstimateLargeN() {
-        Shape s = Shape.fromKM(1, Integer.MAX_VALUE);
+        final Shape s = Shape.fromKM(1, Integer.MAX_VALUE);
         // create a very large filter with Integer.MAX_VALUE-1 bits set.
-        BloomFilter bf1 = new SimpleBloomFilter(s);
+        final BloomFilter bf1 = new SimpleBloomFilter(s);
         bf1.merge((BitMapProducer) predicate -> {
             int limit = Integer.MAX_VALUE - 1;
             while (limit > 64) {
@@ -100,9 +100,9 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
 
     @Test
     public void testIntersectionLimit() {
-        Shape s = Shape.fromKM(1, Integer.MAX_VALUE);
+        final Shape s = Shape.fromKM(1, Integer.MAX_VALUE);
         // create a very large filter with Integer.MAX_VALUE-1 bit set.
-        BloomFilter bf1 = new SimpleBloomFilter(s);
+        final BloomFilter bf1 = new SimpleBloomFilter(s);
         bf1.merge((BitMapProducer) predicate -> {
             int limit = Integer.MAX_VALUE - 1;
             while (limit > 64) {
@@ -122,9 +122,9 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
 
     @Test
     public void testSparseNonSparseMerging() {
-        BloomFilter bf1 = new SparseDefaultBloomFilter(getTestShape());
+        final BloomFilter bf1 = new SparseDefaultBloomFilter(getTestShape());
         bf1.merge(TestingHashers.FROM1);
-        BloomFilter bf2 = new NonSparseDefaultBloomFilter(getTestShape());
+        final BloomFilter bf2 = new NonSparseDefaultBloomFilter(getTestShape());
         bf2.merge(TestingHashers.FROM11);
 
         BloomFilter result = bf1.copy();
@@ -255,7 +255,7 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
 
     static class BrokenCardinality extends NonSparseDefaultBloomFilter {
 
-        BrokenCardinality(Shape shape) {
+        BrokenCardinality(final Shape shape) {
             super(shape);
         }
 

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultIndexProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultIndexProducerTest.java
@@ -124,9 +124,9 @@ public class DefaultIndexProducerTest extends AbstractIndexProducerTest {
 
     @ParameterizedTest
     @ValueSource(ints = {32, 33})
-    public void testEntries(int size) {
-        int[] values = IntStream.range(0, size).toArray();
-        IndexProducer producer =  predicate -> {
+    public void testEntries(final int size) {
+        final int[] values = IntStream.range(0, size).toArray();
+        final IndexProducer producer =  predicate -> {
             Objects.requireNonNull(predicate);
             for (final int i : values) {
                 if (!predicate.test(i)) {
@@ -135,7 +135,7 @@ public class DefaultIndexProducerTest extends AbstractIndexProducerTest {
             }
             return true;
         };
-        int[] other = producer.asIndexArray();
+        final int[] other = producer.asIndexArray();
         assertArrayEquals(values, other);
     }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerFromBitmapProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerFromBitmapProducerTest.java
@@ -84,7 +84,7 @@ public class IndexProducerFromBitmapProducerTest extends AbstractIndexProducerTe
         }
     }
 
-    private static class TestingBitMapProducer implements BitMapProducer {
+    private static final class TestingBitMapProducer implements BitMapProducer {
         long[] values;
 
         TestingBitMapProducer(final long[] values) {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerTest.java
@@ -74,8 +74,8 @@ public class IndexProducerTest {
 
     @ParameterizedTest
     @ValueSource(ints = {32, 33})
-    void testAsIndexArray(int n) {
-        IndexProducer ip = i -> {
+    void testAsIndexArray(final int n) {
+        final IndexProducer ip = i -> {
             for (int j = 0; j < n; j++) {
                 // Always test index zero
                 i.test(0);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/IndexProducerTest.java
@@ -54,7 +54,7 @@ public class IndexProducerTest {
         }
     }
 
-    private static class TestingBitMapProducer implements BitMapProducer {
+    private static final class TestingBitMapProducer implements BitMapProducer {
         long[] values;
 
         TestingBitMapProducer(final long[] values) {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SetOperationsTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SetOperationsTest.java
@@ -208,16 +208,16 @@ public class SetOperationsTest {
     @Test
     public final void testOrCardinality() {
         final Shape shape = Shape.fromKM(3, 128);
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(5, SetOperations::orCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(5, SetOperations::orCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(4, SetOperations::orCardinality, filter1, filter2);
     }
 
@@ -225,32 +225,32 @@ public class SetOperationsTest {
     public final void testOrCardinalityWithDifferentLengthFilters() {
         final Shape shape = Shape.fromKM(3, 128);
         final Shape shape2 = Shape.fromKM(3, 192);
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(5, SetOperations::orCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(5, SetOperations::orCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(4, SetOperations::orCardinality, filter1, filter2);
     }
 
     @Test
     public final void testAndCardinality() {
         final Shape shape = Shape.fromKM(3, 128);
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(1, SetOperations::andCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(0, SetOperations::andCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(1, SetOperations::andCardinality, filter1, filter2);
     }
 
@@ -258,37 +258,37 @@ public class SetOperationsTest {
     public final void testAndCardinalityWithDifferentLengthFilters() {
         final Shape shape = Shape.fromKM(3, 128);
         final Shape shape2 = Shape.fromKM(3, 192);
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(1, SetOperations::andCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(0, SetOperations::andCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(1, SetOperations::andCardinality, filter1, filter2);
     }
 
     @Test
     public final void testXorCardinality() {
         final Shape shape = Shape.fromKM(3, 128);
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(4, SetOperations::xorCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(5, SetOperations::xorCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 64, 69}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 64, 69));
         assertSymmetricOperation(3, SetOperations::xorCardinality, filter1, filter2);
 
         final Shape bigShape = Shape.fromKM(3, 192);
-        filter1 = createFilter(bigShape, IndexProducer.fromIndexArray(new int[] {1, 63, 185}));
-        filter2 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63, 69}));
+        filter1 = createFilter(bigShape, IndexProducer.fromIndexArray(1, 63, 185));
+        filter2 = createFilter(shape, IndexProducer.fromIndexArray(5, 63, 69));
         assertSymmetricOperation(4, SetOperations::xorCardinality, filter1, filter2);
     }
 
@@ -297,23 +297,23 @@ public class SetOperationsTest {
         final Shape shape = Shape.fromKM(3, 128);
         final Shape shape2 = Shape.fromKM(3, 192);
 
-        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63, 64}));
-        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        BloomFilter filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63, 64));
+        BloomFilter filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(4, SetOperations::xorCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {1, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(1, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(5, SetOperations::xorCardinality, filter1, filter2);
 
-        filter1 = createFilter(shape, IndexProducer.fromIndexArray(new int[] {5, 63}));
-        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(new int[] {5, 64, 169}));
+        filter1 = createFilter(shape, IndexProducer.fromIndexArray(5, 63));
+        filter2 = createFilter(shape2, IndexProducer.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(3, SetOperations::xorCardinality, filter1, filter2);
     }
 
     @Test
     public final void testCommutativityOnMismatchedSizes() {
-        final BitMapProducer p1 = BitMapProducer.fromBitMapArray(new long[] {0x3L, 0x5L});
-        final BitMapProducer p2 = BitMapProducer.fromBitMapArray(new long[] {0x1L});
+        final BitMapProducer p1 = BitMapProducer.fromBitMapArray(0x3L, 0x5L);
+        final BitMapProducer p2 = BitMapProducer.fromBitMapArray(0x1L);
 
         assertEquals(SetOperations.orCardinality(p1, p2), SetOperations.orCardinality(p2, p1));
         assertEquals(SetOperations.xorCardinality(p1, p2), SetOperations.xorCardinality(p2, p1));

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterTest.java
@@ -32,12 +32,10 @@ public class SimpleBloomFilterTest extends AbstractBloomFilterTest<SimpleBloomFi
 
     @Test
     public void testMergeShortBitMapProducer() {
-        SimpleBloomFilter filter = createEmptyFilter(getTestShape());
+        final SimpleBloomFilter filter = createEmptyFilter(getTestShape());
         // create a producer that returns too few values
         // shape expects 2 longs we are sending 1.
-        BitMapProducer producer = p -> {
-            return p.test(2L);
-        };
+        final BitMapProducer producer = p -> p.test(2L);
         assertTrue(filter.merge(producer));
         assertEquals(1, filter.cardinality());
     }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/TestingHashers.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/TestingHashers.java
@@ -42,7 +42,7 @@ public class TestingHashers {
      * @param hashers The hashers to merge
      * @return {@code filter} for chaining
      */
-    public static <T extends BloomFilter> T mergeHashers(final T filter, final Hasher...hashers) {
+    public static <T extends BloomFilter> T mergeHashers(final T filter, final Hasher... hashers) {
         for (final Hasher h : hashers) {
             filter.merge(h);
         }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/TestingHashers.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/TestingHashers.java
@@ -42,8 +42,8 @@ public class TestingHashers {
      * @param hashers The hashers to merge
      * @return {@code filter} for chaining
      */
-    public static <T extends BloomFilter> T mergeHashers(T filter, Hasher...hashers) {
-        for (Hasher h : hashers) {
+    public static <T extends BloomFilter> T mergeHashers(final T filter, final Hasher...hashers) {
+        for (final Hasher h : hashers) {
             filter.merge(h);
         }
         return filter;
@@ -55,7 +55,7 @@ public class TestingHashers {
      * @param filter The Bloom filter to populate
      * @return {@code filter} for chaining
      */
-    public static <T extends BloomFilter> T populateFromHashersFrom1AndFrom11(T filter) {
+    public static <T extends BloomFilter> T populateFromHashersFrom1AndFrom11(final T filter) {
         return mergeHashers(filter, FROM1, FROM11);
     }
 
@@ -65,7 +65,7 @@ public class TestingHashers {
      * @param filter the Bloom filter to populate
      * @return {@code filter} for chaining
      */
-    public static <T extends BloomFilter> T populateEntireFilter(T filter) {
+    public static <T extends BloomFilter> T populateEntireFilter(final T filter) {
         return populateRange(filter, 0, filter.getShape().getNumberOfBits() - 1);
     }
 
@@ -77,7 +77,7 @@ public class TestingHashers {
      * @param end the last bit to enable.
      * @return {@code filter} for chaining
      */
-    public static <T extends BloomFilter> T populateRange(T filter, int start, int end) {
+    public static <T extends BloomFilter> T populateRange(final T filter, final int start, final int end) {
         filter.merge((IndexProducer) p -> {
             for (int i = start; i <= end; i++) {
                 if (!p.test(i)) {

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -112,6 +112,8 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         setUpTest();
         c.setMutator(new CompositeCollection.CollectionMutator<E>() {
 
+            private static final long serialVersionUID = 1L;
+
             @Override
             public boolean add(final CompositeCollection<E> composite, final List<Collection<E>> collections, final E obj) {
                 for (final Collection<E> coll : collections) {

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionBuilderTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionBuilderTest.java
@@ -129,7 +129,7 @@ public class PredicatedCollectionBuilderTest {
         assertEquals(3, collection.size());
     }
 
-    private static class OddPredicate implements Predicate<Integer> {
+    private static final class OddPredicate implements Predicate<Integer> {
         @Override
         public boolean evaluate(final Integer value) {
             return value % 2 == 1;

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
@@ -75,7 +75,7 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
     }
 
     protected Predicate<E> testPredicate =
-        o -> o instanceof String;
+        String.class::isInstance;
 
     public Collection<E> makeTestCollection() {
         return decorateCollection(new ArrayList<>(), testPredicate);

--- a/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
@@ -38,14 +38,14 @@ import org.junit.jupiter.api.Test;
  */
 public class TransformedCollectionTest extends AbstractCollectionTest<Object> {
 
-    private static class StringToInteger implements Transformer<Object, Object> {
+    private static final class StringToInteger implements Transformer<Object, Object> {
         @Override
         public Object transform(final Object input) {
             return Integer.valueOf((String) input);
         }
     }
 
-    private static class ToLowerCase implements Transformer<Object, Object> {
+    private static final class ToLowerCase implements Transformer<Object, Object> {
         @Override
         public Object transform(final Object input) {
             return ((String) input).toLowerCase();

--- a/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
@@ -164,7 +164,7 @@ public class ComparatorChainTest extends AbstractComparatorTest<ComparatorChainT
     public static class ColumnComparator implements Comparator<PseudoRow>, Serializable {
         private static final long serialVersionUID = -2284880866328872105L;
 
-        protected int colIndex = 0;
+        protected int colIndex;
 
         public ColumnComparator(final int colIndex) {
             this.colIndex = colIndex;

--- a/src/test/java/org/apache/commons/collections4/functors/ComparatorPredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/ComparatorPredicateTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 
 public class ComparatorPredicateTest extends AbstractPredicateTest {
-    private static class TestComparator<T extends Comparable<T>> implements Comparator<T> {
+    private static final class TestComparator<T extends Comparable<T>> implements Comparator<T> {
         @Override
         public int compare(final T first, final T second) {
             return first.compareTo(second);

--- a/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
@@ -45,10 +45,10 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //--------------------------------------------------------------- Lifecycle
 
-    private Comparator<Integer> comparator = null;
-    private ArrayList<Integer> evens = null;
-    private ArrayList<Integer> odds = null;
-    private ArrayList<Integer> fib = null;
+    private Comparator<Integer> comparator;
+    private ArrayList<Integer> evens;
+    private ArrayList<Integer> odds;
+    private ArrayList<Integer> fib;
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
@@ -39,18 +39,18 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("boxing")
 public class FilterListIteratorTest {
 
-    private ArrayList<Integer> list = null;
-    private ArrayList<Integer> odds = null;
-    private ArrayList<Integer> evens = null;
-    private ArrayList<Integer> threes = null;
-    private ArrayList<Integer> fours = null;
-    private ArrayList<Integer> sixes = null;
-    private Predicate<Integer> truePred = null;
-    private Predicate<Integer> falsePred = null;
-    private Predicate<Integer> evenPred = null;
-    private Predicate<Integer> oddPred = null;
-    private Predicate<Integer> threePred = null;
-    private Predicate<Integer> fourPred = null;
+    private ArrayList<Integer> list;
+    private ArrayList<Integer> odds;
+    private ArrayList<Integer> evens;
+    private ArrayList<Integer> threes;
+    private ArrayList<Integer> fours;
+    private ArrayList<Integer> sixes;
+    private Predicate<Integer> truePred;
+    private Predicate<Integer> falsePred;
+    private Predicate<Integer> evenPred;
+    private Predicate<Integer> oddPred;
+    private Predicate<Integer> threePred;
+    private Predicate<Integer> fourPred;
     private final Random random = new Random();
 
     @BeforeEach

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -41,9 +41,9 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         "One", "Two", "Three", "Four", "Five", "Six"
     };
 
-    protected List<String> list1 = null;
-    protected List<String> list2 = null;
-    protected List<String> list3 = null;
+    protected List<String> list1;
+    protected List<String> list2;
+    protected List<String> list3;
 
     public IteratorChainTest() {
         super(IteratorChainTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
@@ -41,9 +41,9 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         "One", "Two", "Three", "Four", "Five", "Six"
     };
 
-    protected List<String> list1 = null;
-    protected List<String> list2 = null;
-    protected List<String> list3 = null;
+    protected List<String> list1;
+    protected List<String> list2;
+    protected List<String> list3;
 
     public LazyIteratorChainTest() {
         super(LazyIteratorChainTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
@@ -38,7 +38,7 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         "One", "Two", "Three", "Four", "Five", "Six"
     };
 
-    protected List<E> list1 = null;
+    protected List<E> list1;
 
     public ListIteratorWrapper2Test() {
         super(ListIteratorWrapper2Test.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
@@ -39,7 +39,7 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
         "One", "Two", "Three", "Four", "Five", "Six"
     };
 
-    protected List<E> list1 = null;
+    protected List<E> list1;
 
     public ListIteratorWrapperTest() {
         super(ListIteratorWrapperTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
@@ -39,10 +39,10 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
 
     protected String[] testArray = { "One", "Two", "Three", "Four", "Five", "Six" };
 
-    protected List<String> list1 = null;
-    protected List<String> list2 = null;
-    protected List<String> list3 = null;
-    protected List<Iterator<String>> iteratorList = null;
+    protected List<String> list1;
+    protected List<String> list2;
+    protected List<String> list3;
+    protected List<Iterator<String>> iteratorList;
 
     public ObjectGraphIteratorTest() {
         super(ObjectGraphIteratorTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
@@ -36,7 +36,7 @@ public class UniqueFilterIteratorTest<E> extends AbstractIteratorTest<E> {
         "One", "Two", "Three", "Four", "Five", "Six"
     };
 
-    protected List<E> list1 = null;
+    protected List<E> list1;
 
     public UniqueFilterIteratorTest() {
         super(UniqueFilterIteratorTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
@@ -40,9 +40,9 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //--------------------------------------------------------------- Lifecycle
 
-    private ArrayList<Integer> evens = null;
-    private ArrayList<Integer> odds = null;
-    private ArrayList<Integer> fib = null;
+    private ArrayList<Integer> evens;
+    private ArrayList<Integer> odds;
+    private ArrayList<Integer> fib;
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
@@ -59,7 +59,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
     }
 
     protected Predicate<E> testPredicate =
-        o -> o instanceof String;
+        String.class::isInstance;
 
     public List<E> makeTestList() {
         return decorateList(new ArrayList<>(), testPredicate);

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     /** used as a flag in MapMutator tests */
-    private boolean pass = false;
+    private boolean pass;
 
     public CompositeMapTest() {
         super(CompositeMapTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("boxing")
 public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
-    private static class ReverseStringComparator implements Comparator<String> {
+    private static final class ReverseStringComparator implements Comparator<String> {
 
         @Override
         public int compare(final String arg0, final String arg1) {

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
  */
 public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
 
-    private static class TestExpirationPolicy
+    private static final class TestExpirationPolicy
         implements ExpirationPolicy<Integer, String> {
 
         private static final long serialVersionUID = 1L;

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -265,7 +265,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
 
         assertNotNull(map.get("a"));
 
-        try{
+        try {
             Thread.sleep(2 * timeout);
         } catch (final InterruptedException e) {
             fail();

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
@@ -40,7 +40,7 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     protected static final Predicate<Object> truePredicate = TruePredicate.<Object>truePredicate();
 
-    protected static final Predicate<Object> testPredicate = o -> o instanceof String;
+    protected static final Predicate<Object> testPredicate = String.class::isInstance;
 
     public PredicatedMapTest() {
         super(PredicatedMapTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
@@ -52,7 +52,7 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     protected static final Predicate<Object> truePredicate = TruePredicate.truePredicate();
 
-    protected static final Predicate<Object> testPredicate = o -> o instanceof String;
+    protected static final Predicate<Object> testPredicate = String.class::isInstance;
 
     protected final Comparator<K> reverseStringComparator = new ReverseStringComparator();
 

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -346,7 +346,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
-    private static class AccessibleEntry<K, V> extends ReferenceEntry<K, V> {
+    private static final class AccessibleEntry<K, V> extends ReferenceEntry<K, V> {
         final AbstractReferenceMap<K, V> parent;
         final Consumer<V> consumer;
 

--- a/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
@@ -41,7 +41,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
     }
 
     protected Predicate<T> stringPredicate() {
-        return o -> o instanceof String;
+        return String.class::isInstance;
     }
 
     protected Predicate<T> truePredicate = TruePredicate.<T>truePredicate();

--- a/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
@@ -70,7 +70,7 @@ public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
         return list;
     }
 
-    protected Predicate<E> testPredicate = o -> o instanceof String;
+    protected Predicate<E> testPredicate = String.class::isInstance;
 
     public Queue<E> makeTestQueue() {
         return decorateCollection(new LinkedList<>(), testPredicate);

--- a/src/test/java/org/apache/commons/collections4/sequence/SequencesComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/sequence/SequencesComparatorTest.java
@@ -154,7 +154,7 @@ public class SequencesComparatorTest {
         return list;
     }
 
-    private static class ExecutionVisitor<T> implements CommandVisitor<T> {
+    private static final class ExecutionVisitor<T> implements CommandVisitor<T> {
 
         private List<T> v;
         private int index;

--- a/src/test/java/org/apache/commons/collections4/set/AbstractNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractNavigableSetTest.java
@@ -181,15 +181,15 @@ public abstract class AbstractNavigableSetTest<E> extends AbstractSortedSetTest<
         private int highBound;
         private final E[] fullElements;
         private final E[] otherElements;
-        private final boolean m_Inclusive;
+        private final boolean inclusive;
 
         @SuppressWarnings("unchecked")
         public TestNavigableSetSubSet(final int bound, final boolean head, final boolean inclusive) {
             super("TestNavigableSetSubSet");
             if (head) {
-                type = TYPE_HEADSET;
-                m_Inclusive = inclusive;
-                highBound = bound;
+                this.type = TYPE_HEADSET;
+                this.inclusive = inclusive;
+                this.highBound = bound;
 
                 final int realBound = inclusive ? bound + 1 : bound;
                 fullElements = (E[]) new Object[realBound];
@@ -199,7 +199,7 @@ public abstract class AbstractNavigableSetTest<E> extends AbstractSortedSetTest<
                     AbstractNavigableSetTest.this.getOtherElements(), 0, otherElements, 0, bound - 1);
             } else {
                 type = TYPE_TAILSET;
-                m_Inclusive = inclusive;
+                this.inclusive = inclusive;
                 lowBound = bound;
                 final Object[] allElements = AbstractNavigableSetTest.this.getFullElements();
                 final int realBound = inclusive ? bound : bound + 1;
@@ -215,10 +215,10 @@ public abstract class AbstractNavigableSetTest<E> extends AbstractSortedSetTest<
         @SuppressWarnings("unchecked")
         public TestNavigableSetSubSet(final int loBound, final int hiBound, final boolean inclusive) {
             super("TestNavigableSetSubSet");
-            type = TYPE_SUBSET;
-            lowBound = loBound;
-            highBound = hiBound;
-            m_Inclusive = inclusive;
+            this.type = TYPE_SUBSET;
+            this.lowBound = loBound;
+            this.highBound = hiBound;
+            this.inclusive = inclusive;
 
             final int fullLoBound = inclusive ? loBound : loBound + 1;
             final int length = hiBound - loBound + 1 - (inclusive ? 0 : 2);
@@ -260,11 +260,11 @@ public abstract class AbstractNavigableSetTest<E> extends AbstractSortedSetTest<
             final E[] elements = AbstractNavigableSetTest.this.getFullElements();
             switch (type) {
             case TYPE_SUBSET :
-                return set.subSet(elements[lowBound], m_Inclusive, elements[highBound], m_Inclusive);
+                return set.subSet(elements[lowBound], inclusive, elements[highBound], inclusive);
             case TYPE_HEADSET :
-                return set.headSet(elements[highBound], m_Inclusive);
+                return set.headSet(elements[highBound], inclusive);
             case TYPE_TAILSET :
-                return set.tailSet(elements[lowBound], m_Inclusive);
+                return set.tailSet(elements[lowBound], inclusive);
             default :
                 return null;
             }

--- a/src/test/java/org/apache/commons/collections4/set/AbstractSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractSortedSetTest.java
@@ -185,37 +185,37 @@ public abstract class AbstractSortedSetTest<E> extends AbstractSetTest<E> {
 
     public class TestSortedSetSubSet extends AbstractSortedSetTest<E> {
 
-        private final int m_Type;
-        private int m_LowBound;
-        private int m_HighBound;
-        private final E[] m_FullElements;
-        private final E[] m_OtherElements;
+        private final int type;
+        private int lowBound;
+        private int highBound;
+        private final E[] fullElements;
+        private final E[] otherElements;
 
         @SuppressWarnings("unchecked")
         public TestSortedSetSubSet(final int bound, final boolean head) {
             super("TestSortedSetSubSet");
             if (head) {
                 //System.out.println("HEADSET");
-                m_Type = TYPE_HEADSET;
-                m_HighBound = bound;
-                m_FullElements = (E[]) new Object[bound];
-                System.arraycopy(AbstractSortedSetTest.this.getFullElements(), 0, m_FullElements, 0, bound);
-                m_OtherElements = (E[]) new Object[bound - 1];
+                this.type = TYPE_HEADSET;
+                this.highBound = bound;
+                this.fullElements = (E[]) new Object[bound];
+                System.arraycopy(AbstractSortedSetTest.this.getFullElements(), 0, fullElements, 0, bound);
+                this.otherElements = (E[]) new Object[bound - 1];
                 System.arraycopy(//src src_pos dst dst_pos length
-                    AbstractSortedSetTest.this.getOtherElements(), 0, m_OtherElements, 0, bound - 1);
+                    AbstractSortedSetTest.this.getOtherElements(), 0, otherElements, 0, bound - 1);
                 //System.out.println(new TreeSet(Arrays.asList(m_FullElements)));
                 //System.out.println(new TreeSet(Arrays.asList(m_OtherElements)));
             } else {
                 //System.out.println("TAILSET");
-                m_Type = TYPE_TAILSET;
-                m_LowBound = bound;
+                this.type = TYPE_TAILSET;
+                this.lowBound = bound;
                 final Object[] allElements = AbstractSortedSetTest.this.getFullElements();
                 //System.out.println("bound = "+bound +"::length="+allElements.length);
-                m_FullElements = (E[]) new Object[allElements.length - bound];
-                System.arraycopy(allElements, bound, m_FullElements, 0, allElements.length - bound);
-                m_OtherElements = (E[]) new Object[allElements.length - bound - 1];
+                this.fullElements = (E[]) new Object[allElements.length - bound];
+                System.arraycopy(allElements, bound, fullElements, 0, allElements.length - bound);
+                this.otherElements = (E[]) new Object[allElements.length - bound - 1];
                 System.arraycopy(//src src_pos dst dst_pos length
-                    AbstractSortedSetTest.this.getOtherElements(), bound, m_OtherElements, 0, allElements.length - bound - 1);
+                    AbstractSortedSetTest.this.getOtherElements(), bound, otherElements, 0, allElements.length - bound - 1);
                 //System.out.println(new TreeSet(Arrays.asList(m_FullElements)));
                 //System.out.println(new TreeSet(Arrays.asList(m_OtherElements)));
                 //resetFull();
@@ -230,16 +230,16 @@ public abstract class AbstractSortedSetTest<E> extends AbstractSetTest<E> {
         public TestSortedSetSubSet(final int loBound, final int hiBound) {
             super("TestSortedSetSubSet");
             //System.out.println("SUBSET");
-            m_Type = TYPE_SUBSET;
-            m_LowBound = loBound;
-            m_HighBound = hiBound;
+            this.type = TYPE_SUBSET;
+            this.lowBound = loBound;
+            this.highBound = hiBound;
             final int length = hiBound - loBound;
             //System.out.println("Low=" + loBound + "::High=" + hiBound + "::Length=" + length);
-            m_FullElements = (E[]) new Object[length];
-            System.arraycopy(AbstractSortedSetTest.this.getFullElements(), loBound, m_FullElements, 0, length);
-            m_OtherElements = (E[]) new Object[length - 1];
+            this.fullElements = (E[]) new Object[length];
+            System.arraycopy(AbstractSortedSetTest.this.getFullElements(), loBound, fullElements, 0, length);
+            this.otherElements = (E[]) new Object[length - 1];
             System.arraycopy(//src src_pos dst dst_pos length
-                AbstractSortedSetTest.this.getOtherElements(), loBound, m_OtherElements, 0, length - 1);
+                AbstractSortedSetTest.this.getOtherElements(), loBound, otherElements, 0, length - 1);
 
             //System.out.println(new TreeSet(Arrays.asList(m_FullElements)));
             //System.out.println(new TreeSet(Arrays.asList(m_OtherElements)));
@@ -265,22 +265,22 @@ public abstract class AbstractSortedSetTest<E> extends AbstractSetTest<E> {
 
         @Override
         public E[] getFullElements() {
-            return m_FullElements;
+            return fullElements;
         }
         @Override
         public E[] getOtherElements() {
-            return m_OtherElements;
+            return otherElements;
         }
 
         private SortedSet<E> getSubSet(final SortedSet<E> set) {
             final E[] elements = AbstractSortedSetTest.this.getFullElements();
-            switch (m_Type) {
+            switch (type) {
             case TYPE_SUBSET :
-                return set.subSet(elements[m_LowBound], elements[m_HighBound]);
+                return set.subSet(elements[lowBound], elements[highBound]);
             case TYPE_HEADSET :
-                return set.headSet(elements[m_HighBound]);
+                return set.headSet(elements[highBound]);
             case TYPE_TAILSET :
-                return set.tailSet(elements[m_LowBound]);
+                return set.tailSet(elements[lowBound]);
             default :
                 return null;
             }

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
@@ -57,7 +57,7 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
     }
 
     protected Predicate<E> testPredicate =
-        o -> o instanceof String;
+        String.class::isInstance;
 
     protected PredicatedSet<E> makeTestSet() {
         return decorateSet(new HashSet<>(), testPredicate);

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.Test;
  * @since 4.1
  */
 public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
-    protected UnmodifiableNavigableSet<E> set = null;
-    protected ArrayList<E> array = null;
+    protected UnmodifiableNavigableSet<E> set;
+    protected ArrayList<E> array;
 
     public UnmodifiableNavigableSetTest() {
         super(UnmodifiableNavigableSetTest.class.getSimpleName());

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
  * @since 3.0
  */
 public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
-    protected UnmodifiableSortedSet<E> set = null;
-    protected ArrayList<E> array = null;
+    protected UnmodifiableSortedSet<E> set;
+    protected ArrayList<E> array;
 
     public UnmodifiableSortedSetTest() {
         super(UnmodifiableSortedSetTest.class.getSimpleName());


### PR DESCRIPTION
The test : [org.apache.commons.collections4.multimap.HashSetValuedHashMap.testToString](https://github.com/kevin952/commons-collections/blob/af6fff168cc253e82b4b6fcf17be04ebfd6e2b44/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L697)

Lets Dive deeper into this Test and the fix provided for the issue:

**Flakiness:**
To check the flakiness of the test, I used a tool called **[nondex](https://github.com/TestingResearchIllinois/NonDex)**.

You can reproduce the test using the commands below:

   ```shell
  mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.commons.collections4.multimap.HashSetValuedHashMap#testToString
```

Using the commands above I determined the test to be Flaky.

**Issue:**
This was the assertion which failed.
```
        assertTrue(
            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
        );
```
The snippet which cause the issue.
```
    @Override
    protected HashSet<V> createCollection() {
        return new HashSet<>(initialSetCapacity);
    }
```
Error was caused due to the order of the elements not being maintained in the HashSet.

**Fix:**
To fix this issue, Instead of using a HashSet I used a LinkedHashSet which maintain the order of the elements and thus preventing the failure

Do let me know if you have any questions. Please leave a LGTM if you find this fix useful! Thanks!